### PR TITLE
feat(api): deepen the share-link lifecycle into a cohesive module (RFC #12)

### DIFF
--- a/docs/architecture-friction.md
+++ b/docs/architecture-friction.md
@@ -1,0 +1,125 @@
+# Architectural Friction Map
+
+Survey of shallow-module clusters and tightly-coupled concepts worth deepening, ranked best-first. Captured during the May 2026 architecture exploration. No interfaces proposed yet — this is the friction map, not the design.
+
+> **⚠️ Status reconciliation (2026-05-29).** This map is a *historical snapshot* — it is the input that seeded architecture RFCs **#3–#8**, all now **closed**. Every Tier-1 candidate has since been designed and (largely) implemented; see the per-candidate **Status** lines below. The friction *descriptions* are preserved verbatim as a record of the pre-RFC state.
+>
+> Legend: ✅ done · ◑ partial (restructured, residual remains) · ❌ open.
+>
+> - **#4 Share-Link Lifecycle** is now ✅ **done — RFC #12** (a `ShareResolution`-returning resolver + a shared repo-scoped media seam; fixed the 404-vs-410 drift as a correctness win), which also absorbed **#7**'s residual media-resolution drift.
+> - The only notable **code residual** on a "done" item is RFC #7's unshipped `DocumentPolicy` (PR3) and `ProposalPolicy.CanApprove` (PR4). **Tracked: #13** (re-scoped against what RFCs #3/#4 actually shipped).
+> - RFCs **#6** (complete storage abstraction) and **#8** (frontend `LoadController`) shipped in the same wave but don't map 1:1 onto a candidate below.
+
+For background on the "deep module" principle: a deep module has a small interface hiding a large implementation. Shallow modules (interface ≈ implementation) leak complexity to callers, multiply files for one concept, and produce tests that mock the seam instead of verifying behavior.
+
+## How to read this
+
+Each candidate lists:
+- **Files involved** (rough scope)
+- **Friction** — why this hurts navigation, maintenance, or testing today
+- **Coupling reason** — what shared concept the split is fighting
+- **Dependency category**:
+  1. In-process pure
+  2. Local-substitutable (SQLite, filesystem)
+  3. Ports & adapters (remote owned)
+  4. True external (mock)
+- **Test impact** — which existing tests get replaced by boundary tests
+- **Status** — reconciliation against the shipped RFC wave (added 2026-05-29)
+
+---
+
+## Tier 1 — Active obstacles to understanding/testing
+
+### 1. Proposal Approval Merge Seam
+
+`ProposalApprovalService` (Core) + `EfProposalApprovalContext` (Web) + `IProposalApprovalContext` + 3 event handlers (~6 files, ~600 LOC)
+
+- **Friction**: Domain logic is in Core but the transaction boundary, store calls, and event publishing live in the Web-layer adapter. Reading the merge flow requires bouncing Core → Web → back. Tests have to mock 8 store methods.
+- **Coupling**: Domain rules + persistence orchestration + transaction + event fan-out artificially split.
+- **Deps**: (2) local-substitutable (SQLite via EF in-memory/file).
+- **Test impact**: `ProposalApprovalServiceTests` wholesale mock disappears; `EfProposalApprovalContext` (currently untested) gets covered by boundary tests.
+- **Status (2026-05-29)**: ✅ **Done — RFC #3** (`8fe263f`). `IProposalApprovalContext` is now a single deep port; `PersistMergeAsync` owns the one merge transaction plus the pre/post-commit event split. The "≈50-line in-memory test adapter" shape this map predicted shipped as designed.
+
+### 2. Authorization (RBAC + Domain Policies)
+
+`AuthorizationHelper` (static role predicates) + `ProposalPolicy` + `CommentPolicy` + `ShareLinkPolicy` + `PolicyResult` + extensions (~6 files, ~400 LOC)
+
+- **Friction**: Two parallel authorization systems. Endpoints call `AuthorizationHelper.CanContribute()` then separately call `ProposalPolicy.CanUpdate()`. Changing "who can update a proposal" touches one place; changing "what roles can contribute" touches another. They don't compose.
+- **Coupling**: Repository-level RBAC and entity-level domain rules co-own the "is this allowed?" concept.
+- **Deps**: (1) in-process pure + (2) membership store lookup.
+- **Test impact**: `RbacContractTests` + per-policy tests collapse into authorization-decision tests at the gate.
+- **Status (2026-05-29)**: ✅ **Done — RFC #7** (`f9fe970` PR1, `3cd52cf` PR2). `PolicyResult` + `ProposalPolicy`/`CommentPolicy`/`ShareLinkPolicy` + `PolicyResultExtensions.ToHttp()` shipped. ⚠️ **Residual:** `DocumentPolicy` (PR3) and `ProposalPolicy.CanApprove` (PR4) were never implemented — approval preconditions still live inline in `ProposalApprovalService`, and a stale doc-comment at `ProposalPolicy.cs:15` still references the missing `CanApprove`. **→ tracked as #13** (note: PR3 `DocumentPolicy` is largely overtaken by RFC #4's command layer, so #13 re-scopes rather than follows the original plan).
+
+### 3. Thin Service Delegates
+
+`TierService`, `FrontmatterService`, `DiffService`, `SignatureService`, ~10 others in `Api/` (~14 files, ~800 LOC)
+
+- **Friction**: Each is a 1:1 pass-through over a store/library. `TierService.GetLimitsAsync` makes 3 separate settings reads with no "tier config" concept. `FrontmatterService` wraps YamlDotNet → JSON. They were extracted "for testability" but the boundaries don't carve at real joints.
+- **Coupling**: Each "service" owns one verb; the conceptual cluster (tiering, frontmatter, signing) is fragmented.
+- **Deps**: mix of (1) pure and (2) local.
+- **Test impact**: existing tests mostly mock these; moving the boundary surfaces fewer, more meaningful tests.
+- **Status (2026-05-29)**: ◑ **Partial — RFC #4** (command-service wave, e.g. `60dea9c`). Per-aggregate command services (`Document`/`Media`/`Membership`/`ProposalCommandService`) now absorb the endpoint prelude/postlude and consume the utility services behind ports, so they are no longer the top-level seam. But the named thin delegates themselves — `TierService`, `FrontmatterService`, `DiffService`, `SignatureService` — still exist 1:1 in `Web/Api/`; that specific consolidation was not done.
+
+---
+
+## Tier 2 — Scatter and seam-test waste
+
+### 4. Share-Link Lifecycle
+
+`ShareLinkTokenService` (static) + `ShareLinkEndpoints` (creation + auth) + anonymous resolve endpoint + share-media endpoint (~4 files, ~400 LOC)
+
+- **Friction**: Token gen / hash / display-prefix live as separate static functions. Validation logic is duplicated between authenticated and anonymous paths. Anonymous media-by-name route partly duplicates `MediaEndpoints` logic.
+- **Coupling**: Crypto + validation + consumption all one concept, split for "reusability."
+- **Deps**: (1) pure crypto + (2) local store.
+- **Status (2026-06-13)**: ✅ **Done — RFC #12.** `ShareLinkResolver` (Core, `Scribegate.Core.ShareLinks`) now owns prefix-check + hash + revoked/expired validation + pinned-vs-current revision selection and returns a `ShareResolution`; `ShareResolutionExtensions.ToError()` is the one lifecycle→HTTP mapping (fixes the 404-vs-410 drift). The repo-scoped media seam `RepoMediaResolver.StreamByNameAsync` is reused by both the anonymous share path and `MediaEndpoints.DownloadMediaByName`, folding in #7's residual. Token primitives moved Web→Core. (Earlier: only `ShareLinkPolicy.CanRevoke` had shipped, RFC #7 PR2.)
+
+### 5. Audit + Retention
+
+`AuditService` + `AuditRetentionService` + 50+ `Audit*Handler` classes + `DomainEventSaveChangesInterceptor` (~8 files, ~1500 LOC)
+
+- **Friction**: 50 handlers each delegate to `AuditService` in 3-5 lines. Retention lives as an isolated background service. The full audit lifecycle (write → store → expire) requires reading three layers.
+- **Coupling**: Audit-write boilerplate repeated 50×; lifecycle phases split across modules.
+- **Deps**: (1) pure + (2) local SQLite.
+- **Status (2026-05-29)**: ◑ **Partial — RFC #5** (`4d40f90`). Audit fan-out now rides the domain bus with a pre/post-commit split (the orphan-audit and SMTP-blocking bugs this implied are fixed). Per-handler boilerplate persists *by design* — each side-effect is a bus subscriber (~57 handler files); `AuditService` + `AuditRetentionService` remain separate modules.
+
+### 6. Webhook Dispatch + Delivery
+
+`WebhookDispatcher` (Channel queue) + `WebhookDeliveryWorker` (HTTP + retry + signing) + 20+ event handlers + `WebhookUrlValidator` + `WebhookSerialization` (~8 files, ~1200 LOC)
+
+- **Friction**: Queue, delivery, signing, retry policy, and URL validation are all separate. Changing retry semantics edits the worker; changing what's signed traces into the worker's signing block; URL validation is its own helper. 20 handlers all do enqueue-with-payload boilerplate.
+- **Deps**: (4) true external (HTTP) + (1) pure signing.
+- **Status (2026-05-29)**: ◑ **Partial — RFC #5** (`4d40f90`). Webhook fan-out now flows through the post-commit bus, removing the per-endpoint enqueue boilerplate. The dispatcher / worker / signing / URL-validation internals were not re-consolidated into one deep module.
+
+---
+
+## Tier 3 — Duplication
+
+### 7. Media Asset Lifecycle
+
+`MediaEndpoints` (upload + list + download + by-name) + `MediaCommandService` (Core) + `MediaAssetStore` + duplicated share-link anonymous media path (~5 files, ~700 LOC)
+
+- **Friction**: Two routes resolve media (authenticated, share-scoped) with overlapping logic. Quota enforcement is buried inside `MediaCommandService.UploadAsync` instead of at a quota boundary. Anonymous and authenticated paths drift.
+- **Deps**: (2) local filesystem + SQLite.
+- **Status (2026-05-29)**: ◑ **Partial — RFC #4** (`60dea9c`, `MediaCommandService`). Upload + quota now live at a real command boundary. The dual by-name resolution drift (authenticated `MediaEndpoints` vs the anonymous share path) remains — it folds into the open **#4** work above.
+
+### 8. Event Handler Orchestration
+
+50+ `DomainEventHandler` classes + `DomainEventBus` + `DomainEventScope` (~5+ files, ~2000 LOC of handlers)
+
+- **Friction**: Each handler is 3-5 lines of "fetch service, call method." Adding a side effect means writing a new handler class + wiring DI. Side-effect fan-out is not a first-class concept.
+- **Deps**: (4) external (email, webhooks) + (1) pure.
+- **Status (2026-05-29)**: ◑ **Partial — RFC #5** (`4d40f90`). `IDomainEventBus` + `DomainEventScope`'s pre/post-commit split now make side-effect fan-out a first-class concept with correct transactional semantics. The "~50 thin handler classes" count is essentially unchanged by design — each subscriber is one handler.
+
+---
+
+## Cross-cutting pattern
+
+Across all clusters: extraction "for testability" produced shallow seams where interface ≈ implementation, and the tests that resulted mostly mock the seam wholesale rather than verifying behavior at a real boundary. Deepening means moving the boundary outward (toward the real coupling) and testing through the new boundary instead.
+
+## Suggested next step
+
+> **Updated 2026-05-29.** The original "#1 and #2 are the natural first targets" advice is **spent** — RFC #3 (#1) and RFC #7 (#2) are closed and shipped, and the rest of Tier 1–3 was largely absorbed by RFCs #4 and #5. The remaining work, best-first:
+>
+> 1. ~~**#4 Share-Link Lifecycle**~~ — ✅ **Done, RFC #12** (a `ShareResolution`-returning resolver + a shared repo-scoped media seam; fixed the 404-vs-410 drift as a correctness win). It subsumed **#7**'s media-resolution residual.
+> 2. **RFC #7 residual**, filed as **#13** — reconciliation, not blind finishing: fix the stale `CanApprove` doc-comment, decide whether to extract `ProposalPolicy.CanApprove` (vs. let RFC #3's inline `ApprovalResult` win), and re-scope `DocumentPolicy` (largely overtaken by RFC #4's command layer) to the minimum missing guard.
+> 3. **#3 thin-delegate consolidation** (optional) — only if `TierService`/`FrontmatterService`/`DiffService`/`SignatureService` start actively obstructing a change; they're now hidden behind the RFC #3/#4 ports, so the pressure is low.

--- a/src/Scribegate.Core/ShareLinks/ResolvedShare.cs
+++ b/src/Scribegate.Core/ShareLinks/ResolvedShare.cs
@@ -1,0 +1,16 @@
+using Scribegate.Core.Entities;
+
+namespace Scribegate.Core.ShareLinks;
+
+/// <summary>
+/// What an anonymous holder of a valid share token is allowed to see.
+/// <see cref="Revision"/> is the <em>effective</em> revision — the link's
+/// pinned revision when set, otherwise the document's current revision.
+/// <see cref="Repository"/>'s Owner is eager-loaded (the
+/// <c>IShareLinkStore.GetByTokenHashAsync</c> contract).
+/// </summary>
+public sealed record ResolvedShare(
+    ShareLink Link,
+    Revision Revision,
+    Repository Repository,
+    Document Document);

--- a/src/Scribegate.Core/ShareLinks/ShareLinkLifecycle.cs
+++ b/src/Scribegate.Core/ShareLinks/ShareLinkLifecycle.cs
@@ -1,0 +1,18 @@
+using Scribegate.Core.Entities;
+
+namespace Scribegate.Core.ShareLinks;
+
+/// <summary>
+/// The share-link revoked/expired predicates, single-sourced so the consume path
+/// (<see cref="ShareLinkResolver"/>) and the owner-facing listing agree on the
+/// boundary — including the exact-equality tick: a link is live up to and
+/// including <c>ExpiresAt</c>, expired only strictly after it.
+/// </summary>
+public static class ShareLinkLifecycle
+{
+    public static bool IsExpired(ShareLink link, DateTime now) =>
+        link.ExpiresAt.HasValue && link.ExpiresAt.Value < now;
+
+    public static bool IsActive(ShareLink link, DateTime now) =>
+        !link.RevokedAt.HasValue && !IsExpired(link, now);
+}

--- a/src/Scribegate.Core/ShareLinks/ShareLinkResolver.cs
+++ b/src/Scribegate.Core/ShareLinks/ShareLinkResolver.cs
@@ -15,7 +15,7 @@ public sealed class ShareLinkResolver(IShareLinkStore links, IRevisionStore revi
 {
     public async Task<ShareResolution> ResolveAsync(string token, DateTime now, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(token) || !token.StartsWith(ShareLinkTokenDefaults.TokenPrefix))
+        if (string.IsNullOrWhiteSpace(token) || !token.StartsWith(ShareLinkTokenDefaults.TokenPrefix, StringComparison.Ordinal))
             return ShareResolution.NotFound();
 
         var tokenHash = ShareLinkTokenService.HashToken(token);

--- a/src/Scribegate.Core/ShareLinks/ShareLinkResolver.cs
+++ b/src/Scribegate.Core/ShareLinks/ShareLinkResolver.cs
@@ -1,0 +1,42 @@
+using Scribegate.Core.Entities;
+using Scribegate.Core.Stores;
+
+namespace Scribegate.Core.ShareLinks;
+
+/// <summary>
+/// The single source of truth for consuming a share token: token-prefix check,
+/// hash, store lookup, revoked / expired lifecycle validation, and pinned-vs-current
+/// revision selection. Read-only — creation (and its Contributor+ RBAC gate) stays
+/// at the endpoint. The HTTP/status mapping of a non-Ok result is decided once in
+/// the Web layer (<c>ShareResolutionExtensions.ToError()</c>), so the document and
+/// media resolve paths share one contract.
+/// </summary>
+public sealed class ShareLinkResolver(IShareLinkStore links, IRevisionStore revisions)
+{
+    public async Task<ShareResolution> ResolveAsync(string token, DateTime now, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(token) || !token.StartsWith(ShareLinkTokenDefaults.TokenPrefix))
+            return ShareResolution.NotFound();
+
+        var tokenHash = ShareLinkTokenService.HashToken(token);
+        var link = await links.GetByTokenHashAsync(tokenHash, ct);
+        if (link is null) return ShareResolution.NotFound();
+
+        if (link.RevokedAt.HasValue) return ShareResolution.Revoked();
+        if (ShareLinkLifecycle.IsExpired(link, now)) return ShareResolution.Expired();
+
+        // Effective revision: pinned link revision, else the document's current.
+        // The common path is fully eager-loaded by GetByTokenHashAsync; the
+        // revisionStore fetch is a defensive fallback.
+        Revision? revision = link.Revision;
+        if (revision is null)
+        {
+            var currentRevId = link.Document.CurrentRevisionId;
+            if (!currentRevId.HasValue) return ShareResolution.NotFound();
+            revision = link.Document.CurrentRevision ?? await revisions.GetByIdAsync(currentRevId.Value, ct);
+        }
+        if (revision is null) return ShareResolution.NotFound();
+
+        return ShareResolution.Ok(new ResolvedShare(link, revision, link.Repository, link.Document));
+    }
+}

--- a/src/Scribegate.Core/ShareLinks/ShareLinkTokenService.cs
+++ b/src/Scribegate.Core/ShareLinks/ShareLinkTokenService.cs
@@ -1,7 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Scribegate.Web.Api;
+namespace Scribegate.Core.ShareLinks;
 
 public static class ShareLinkTokenDefaults
 {

--- a/src/Scribegate.Core/ShareLinks/ShareResolution.cs
+++ b/src/Scribegate.Core/ShareLinks/ShareResolution.cs
@@ -1,0 +1,28 @@
+namespace Scribegate.Core.ShareLinks;
+
+/// <summary>
+/// Lifecycle state of a share token after the resolver has validated it.
+/// The Web layer maps each state to an HTTP contract in exactly one place
+/// (<c>ShareResolutionExtensions.ToError()</c>), so the 404-vs-410 decision
+/// can no longer drift between the document and media resolve paths.
+/// </summary>
+public enum ShareState
+{
+    Ok,
+    NotFound,
+    Revoked,
+    Expired,
+}
+
+/// <summary>
+/// Discriminated outcome of <see cref="ShareLinkResolver.ResolveAsync"/>. A
+/// non-<see cref="ShareState.Ok"/> state carries a null <see cref="Share"/>;
+/// <see cref="ShareState.Ok"/> always carries one.
+/// </summary>
+public readonly record struct ShareResolution(ShareState State, ResolvedShare? Share)
+{
+    public static ShareResolution NotFound() => new(ShareState.NotFound, null);
+    public static ShareResolution Revoked() => new(ShareState.Revoked, null);
+    public static ShareResolution Expired() => new(ShareState.Expired, null);
+    public static ShareResolution Ok(ResolvedShare s) => new(ShareState.Ok, s);
+}

--- a/src/Scribegate.Core/ShareLinks/ShareResolution.cs
+++ b/src/Scribegate.Core/ShareLinks/ShareResolution.cs
@@ -8,6 +8,10 @@ namespace Scribegate.Core.ShareLinks;
 /// </summary>
 public enum ShareState
 {
+    // Zero slot is a non-Ok sentinel so a default-initialized ShareResolution
+    // (default(ShareResolution), an empty-sequence FirstOrDefault, etc.) can't
+    // masquerade as a successful resolution with a null Share.
+    Unknown = 0,
     Ok,
     NotFound,
     Revoked,

--- a/src/Scribegate.Web/Api/MediaEndpoints.cs
+++ b/src/Scribegate.Web/Api/MediaEndpoints.cs
@@ -210,26 +210,15 @@ public static class MediaEndpoints
         HttpContext http,
         CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(fileName)
-            || fileName.Contains('/')
-            || fileName.Contains('\\')
-            || fileName.Contains('\0')
-            || fileName == "." || fileName == "..")
-            return ApiResults.NotFound("Media", fileName);
-
         var repo = await repoStore.GetByOwnerAndSlugAsync(owner, repoSlug, ct);
         if (repo is null) return ApiResults.NotFound("Repository", repoSlug);
 
         if (!await authz.CanReadRepositoryAsync(repo, http, userContext, ct))
             return ApiResults.NotFound("Repository", repoSlug);
 
-        var asset = await mediaAssets.FindLatestByFileNameAsync(repo.Id, fileName, ct);
-        if (asset is null) return ApiResults.NotFound("Media", fileName);
-
-        if (!File.Exists(asset.StoragePath))
-            return ApiResults.NotFound("Media", fileName);
-
-        return Results.File(asset.StoragePath, asset.ContentType, asset.FileName);
+        // Repo scope established (repo-read RBAC); sanitize + lookup + stream is
+        // the shared seam the anonymous share path also uses.
+        return await RepoMediaResolver.StreamByNameAsync(mediaAssets, repo.Id, fileName, ct);
     }
 
     private static async Task<IResult> DeleteMedia(

--- a/src/Scribegate.Web/Api/RepoMediaResolver.cs
+++ b/src/Scribegate.Web/Api/RepoMediaResolver.cs
@@ -1,0 +1,38 @@
+using Scribegate.Core.Stores;
+using Scribegate.Web.Models;
+
+namespace Scribegate.Web.Api;
+
+/// <summary>
+/// The single repo-scoped media-by-name seam: filename sanitization →
+/// <c>FindLatestByFileNameAsync</c> → <c>File.Exists</c> → <c>Results.File</c>.
+/// Both the authenticated <c>MediaEndpoints.DownloadMediaByName</c> and the
+/// anonymous <c>ShareLinkEndpoints.ResolveShareMediaByName</c> call this once
+/// their own repo scope is established (repo-read RBAC vs the share token), so
+/// the sanitization rules, content-type handling, and missing-file behavior can
+/// no longer drift between the two paths. Web-layer (not Core) because it touches
+/// the filesystem and produces an <see cref="IResult"/>.
+/// </summary>
+public static class RepoMediaResolver
+{
+    public static async Task<IResult> StreamByNameAsync(
+        IMediaAssetStore mediaAssets,
+        Guid repoId,
+        string fileName,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(fileName)
+            || fileName.Contains('/')
+            || fileName.Contains('\\')
+            || fileName.Contains('\0')
+            || fileName == "." || fileName == "..")
+            return ApiResults.NotFound("Media", fileName);
+
+        var asset = await mediaAssets.FindLatestByFileNameAsync(repoId, fileName, ct);
+        if (asset is null) return ApiResults.NotFound("Media", fileName);
+
+        if (!File.Exists(asset.StoragePath)) return ApiResults.NotFound("Media", fileName);
+
+        return Results.File(asset.StoragePath, asset.ContentType, asset.FileName);
+    }
+}

--- a/src/Scribegate.Web/Api/ShareLinkEndpoints.cs
+++ b/src/Scribegate.Web/Api/ShareLinkEndpoints.cs
@@ -1,6 +1,7 @@
 using Scribegate.Core.Authorization;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Events;
+using Scribegate.Core.ShareLinks;
 using Scribegate.Core.Stores;
 using Scribegate.Web.Models;
 
@@ -187,7 +188,7 @@ public static class ShareLinkEndpoints
             RevokedAt = l.RevokedAt,
             LastAccessedAt = l.LastAccessedAt,
             AccessCount = l.AccessCount,
-            IsActive = IsActive(l, now),
+            IsActive = ShareLinkLifecycle.IsActive(l, now),
         }).ToList();
 
         return Results.Ok(new ShareLinkListResponse { Items = items, Total = items.Count });
@@ -242,50 +243,17 @@ public static class ShareLinkEndpoints
 
     private static async Task<IResult> ResolveShareLink(
         string token,
+        ShareLinkResolver resolver,
         IShareLinkStore shareLinkStore,
-        IRevisionStore revisionStore,
         IDomainEventBus events,
         CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(token) || !token.StartsWith(ShareLinkTokenDefaults.TokenPrefix))
-            return ShareNotFound();
+        var resolution = await resolver.ResolveAsync(token, DateTime.UtcNow, ct);
+        if (resolution.State != ShareState.Ok) return resolution.ToError();
 
-        var tokenHash = ShareLinkTokenService.HashToken(token);
-        var link = await shareLinkStore.GetByTokenHashAsync(tokenHash, ct);
-        if (link is null) return ShareNotFound();
-
-        if (link.RevokedAt.HasValue)
-            return Results.Json(new
-            {
-                error = new ApiError
-                {
-                    Code = ApiErrorCodes.Revoked,
-                    Message = "This share link has been revoked.",
-                    Details = "Ask the person who shared it to create a new link.",
-                }
-            }, statusCode: 410);
-
-        if (link.ExpiresAt.HasValue && link.ExpiresAt.Value < DateTime.UtcNow)
-            return Results.Json(new
-            {
-                error = new ApiError
-                {
-                    Code = ApiErrorCodes.Expired,
-                    Message = "This share link has expired.",
-                    Details = "Ask the person who shared it to create a new link.",
-                }
-            }, statusCode: 410);
-
-        // Determine revision: pinned or latest
-        Revision? revision = link.Revision;
-        if (revision is null)
-        {
-            var currentRevId = link.Document.CurrentRevisionId;
-            if (!currentRevId.HasValue)
-                return ShareNotFound();
-            revision = link.Document.CurrentRevision ?? await revisionStore.GetByIdAsync(currentRevId.Value, ct);
-        }
-        if (revision is null) return ShareNotFound();
+        var share = resolution.Share!;
+        var link = share.Link;
+        var revision = share.Revision;
 
         // Capture response data before the best-effort write so a failure there
         // cannot leak secondary state or change what we return.
@@ -293,10 +261,10 @@ public static class ShareLinkEndpoints
         {
             // Owner is eagerly included by IShareLinkStore.GetByTokenHashAsync;
             // the null-forgiving `!` reflects that contract.
-            RepositoryOwner = link.Repository.Owner!.Username,
-            RepositorySlug = link.Repository.Slug,
-            RepositoryName = link.Repository.Name,
-            DocumentPath = link.Document.Path,
+            RepositoryOwner = share.Repository.Owner!.Username,
+            RepositorySlug = share.Repository.Slug,
+            RepositoryName = share.Repository.Name,
+            DocumentPath = share.Document.Path,
             Content = revision.Content,
             RevisionId = revision.Id,
             RevisionMessage = revision.Message,
@@ -340,46 +308,17 @@ public static class ShareLinkEndpoints
     private static async Task<IResult> ResolveShareMediaByName(
         string token,
         string fileName,
-        IShareLinkStore shareLinkStore,
+        ShareLinkResolver resolver,
         IMediaAssetStore mediaAssets,
         CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(fileName)
-            || fileName.Contains('/')
-            || fileName.Contains('\\')
-            || fileName.Contains('\0')
-            || fileName == "." || fileName == "..")
-            return ShareNotFound();
+        // Same lifecycle contract as ResolveShareLink (revoked/expired → 410).
+        // Deliberately does NOT bump AccessCount / emit ShareLinkAccessedEvent —
+        // a doc with N inline images must not inflate the link's access count.
+        var resolution = await resolver.ResolveAsync(token, DateTime.UtcNow, ct);
+        if (resolution.State != ShareState.Ok) return resolution.ToError();
 
-        if (string.IsNullOrWhiteSpace(token) || !token.StartsWith(ShareLinkTokenDefaults.TokenPrefix))
-            return ShareNotFound();
-
-        var tokenHash = ShareLinkTokenService.HashToken(token);
-        var link = await shareLinkStore.GetByTokenHashAsync(tokenHash, ct);
-        if (link is null) return ShareNotFound();
-        if (link.RevokedAt.HasValue) return ShareNotFound();
-        if (link.ExpiresAt.HasValue && link.ExpiresAt.Value < DateTime.UtcNow)
-            return ShareNotFound();
-
-        var asset = await mediaAssets.FindLatestByFileNameAsync(link.RepositoryId, fileName, ct);
-        if (asset is null) return ShareNotFound();
-
-        if (!File.Exists(asset.StoragePath)) return ShareNotFound();
-
-        return Results.File(asset.StoragePath, asset.ContentType, asset.FileName);
+        return await RepoMediaResolver.StreamByNameAsync(
+            mediaAssets, resolution.Share!.Repository.Id, fileName, ct);
     }
-
-    private static IResult ShareNotFound() =>
-        Results.Json(new
-        {
-            error = new ApiError
-            {
-                Code = ApiErrorCodes.NotFound,
-                Message = "Share link not found.",
-                Details = "The link may have been revoked, expired, or typed incorrectly.",
-            }
-        }, statusCode: 404);
-
-    private static bool IsActive(ShareLink link, DateTime now) =>
-        !link.RevokedAt.HasValue && (!link.ExpiresAt.HasValue || link.ExpiresAt.Value > now);
 }

--- a/src/Scribegate.Web/Api/ShareResolutionExtensions.cs
+++ b/src/Scribegate.Web/Api/ShareResolutionExtensions.cs
@@ -1,0 +1,48 @@
+using Scribegate.Core.ShareLinks;
+using Scribegate.Web.Models;
+
+namespace Scribegate.Web.Api;
+
+/// <summary>
+/// Maps a non-Ok <see cref="ShareResolution"/> to its HTTP response. This is the
+/// ONE authoritative place the share lifecycle → HTTP contract is decided, so the
+/// document and media resolve paths can't drift (the historical 404-vs-410 bug).
+/// Separate from <see cref="PolicyResultExtensions.ToHttp"/> because
+/// <c>PolicyResult.HttpStatus</c> only models {200, 403, 409, 422} — never the
+/// 404 / 410 a share lifecycle produces.
+/// </summary>
+public static class ShareResolutionExtensions
+{
+    public static IResult ToError(this ShareResolution r) => r.State switch
+    {
+        ShareState.Revoked => Results.Json(new
+        {
+            error = new ApiError
+            {
+                Code = ApiErrorCodes.Revoked,
+                Message = "This share link has been revoked.",
+                Details = "Ask the person who shared it to create a new link.",
+            }
+        }, statusCode: 410),
+        ShareState.Expired => Results.Json(new
+        {
+            error = new ApiError
+            {
+                Code = ApiErrorCodes.Expired,
+                Message = "This share link has expired.",
+                Details = "Ask the person who shared it to create a new link.",
+            }
+        }, statusCode: 410),
+        ShareState.Ok => throw new InvalidOperationException(
+            "ToError() called on an Ok ShareResolution — guard on State != Ok before mapping to an error."),
+        _ => Results.Json(new
+        {
+            error = new ApiError
+            {
+                Code = ApiErrorCodes.NotFound,
+                Message = "Share link not found.",
+                Details = "The link may have been revoked, expired, or typed incorrectly.",
+            }
+        }, statusCode: 404),
+    };
+}

--- a/src/Scribegate.Web/Program.cs
+++ b/src/Scribegate.Web/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddScoped<Scribegate.Core.Services.IMediaCommandContext, Scribe
 builder.Services.AddScoped<Scribegate.Core.Services.MediaCommandService>();
 builder.Services.AddScoped<Scribegate.Core.Services.IProposalCommandContext, Scribegate.Web.Services.EfProposalCommandContext>();
 builder.Services.AddScoped<Scribegate.Core.Services.ProposalCommandService>();
+builder.Services.AddScoped<Scribegate.Core.ShareLinks.ShareLinkResolver>();
 
 // Webhook dispatch: singleton queue + hosted worker; HttpClient factory for deliveries
 builder.Services.AddSingleton<Scribegate.Web.Services.WebhookDispatcher>();

--- a/tests/Scribegate.Core.Tests/ShareLinkResolverTests.cs
+++ b/tests/Scribegate.Core.Tests/ShareLinkResolverTests.cs
@@ -1,0 +1,314 @@
+using FluentAssertions;
+using Scribegate.Core.Entities;
+using Scribegate.Core.ShareLinks;
+using Scribegate.Core.Stores;
+using Xunit;
+
+namespace Scribegate.Core.Tests;
+
+// Branch coverage for ShareLinkResolver — the single source of truth for
+// consuming a share token (prefix-check → hash → lookup → revoked → expired →
+// pinned-vs-current revision). The resolver depends on two ports
+// (IShareLinkStore + IRevisionStore); the hand-rolled in-memory fakes at the
+// bottom of this file substitute the EF/SQLite stores so every ShareState
+// branch is exercised without Web/Data dependencies. Expiry is driven purely
+// through the `now` parameter — no wall-clock — so the boundary is deterministic.
+public class ShareLinkResolverTests
+{
+    private const string ValidToken = "sl_validtokenbody1234567890";
+    private static readonly DateTime Now = new(2026, 6, 13, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Resolve_ActiveLink_Returns_Ok_WithResolvedShare()
+    {
+        var (links, revisions, link, currentRev) = Seed();
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Ok);
+        var share = result.Share.Should().NotBeNull().And.Subject.As<ResolvedShare>();
+        share.Link.Should().BeSameAs(link);
+        share.Revision.Should().BeSameAs(currentRev);
+        share.Repository.Should().BeSameAs(link.Repository);
+        share.Document.Should().BeSameAs(link.Document);
+    }
+
+    [Fact]
+    public async Task Resolve_TokenMissingPrefix_Returns_NotFound_WithoutStoreLookup()
+    {
+        var (links, revisions, _, _) = Seed();
+
+        var result = await new ShareLinkResolver(links, revisions)
+            .ResolveAsync("not-a-share-token", Now, default);
+
+        result.State.Should().Be(ShareState.NotFound);
+        result.Share.Should().BeNull();
+        // A malformed token must short-circuit before hitting the store.
+        links.LookupCount.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Resolve_NullOrWhitespaceToken_Returns_NotFound(string? token)
+    {
+        var (links, revisions, _, _) = Seed();
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(token!, Now, default);
+
+        result.State.Should().Be(ShareState.NotFound);
+        result.Share.Should().BeNull();
+        links.LookupCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Resolve_UnknownTokenHash_Returns_NotFound()
+    {
+        // Well-formed prefix, but no link with this hash exists in the store.
+        var (links, revisions, _, _) = Seed();
+
+        var result = await new ShareLinkResolver(links, revisions)
+            .ResolveAsync("sl_doesnotexist", Now, default);
+
+        result.State.Should().Be(ShareState.NotFound);
+        result.Share.Should().BeNull();
+        links.LookupCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Resolve_RevokedLink_Returns_Revoked()
+    {
+        var (links, revisions, link, _) = Seed();
+        link.RevokedAt = Now.AddMinutes(-1);
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Revoked);
+        result.Share.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Resolve_RevokedTakesPrecedence_OverExpired()
+    {
+        // A link that is both revoked AND expired surfaces Revoked — the impl
+        // checks RevokedAt before ExpiresAt.
+        var (links, revisions, link, _) = Seed();
+        link.RevokedAt = Now.AddMinutes(-1);
+        link.ExpiresAt = Now.AddMinutes(-1);
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Revoked);
+    }
+
+    [Fact]
+    public async Task Resolve_ExpiredLink_Returns_Expired()
+    {
+        var (links, revisions, link, _) = Seed();
+        link.ExpiresAt = Now.AddSeconds(-1); // strictly before `now`
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Expired);
+        result.Share.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Resolve_ExpiresAt_ExactlyEqualToNow_IsNotExpired()
+    {
+        // Pins the `ExpiresAt.Value < now` operator: equality is NOT expired.
+        var (links, revisions, link, _) = Seed();
+        link.ExpiresAt = Now;
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Ok);
+    }
+
+    [Fact]
+    public async Task Resolve_ExpiresAt_OneTickAfterNow_IsNotExpired()
+    {
+        var (links, revisions, link, _) = Seed();
+        link.ExpiresAt = Now.AddTicks(1);
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Ok);
+    }
+
+    [Fact]
+    public async Task Resolve_NoExpiry_IsNeverExpired()
+    {
+        var (links, revisions, link, _) = Seed();
+        link.ExpiresAt = null;
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Ok);
+    }
+
+    [Fact]
+    public async Task Resolve_PinnedRevision_ReturnsThatRevision_NotCurrent()
+    {
+        var (links, revisions, link, currentRev) = Seed();
+        var pinned = NewRevision(link.DocumentId, "# Pinned");
+        link.RevisionId = pinned.Id;
+        link.Revision = pinned;
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Ok);
+        result.Share!.Revision.Should().BeSameAs(pinned);
+        result.Share.Revision.Should().NotBeSameAs(currentRev);
+    }
+
+    [Fact]
+    public async Task Resolve_NoPinnedRevision_FallsBackToDocumentCurrentRevision()
+    {
+        var (links, revisions, link, currentRev) = Seed();
+        link.RevisionId = null;
+        link.Revision = null;
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Ok);
+        result.Share!.Revision.Should().BeSameAs(currentRev);
+    }
+
+    [Fact]
+    public async Task Resolve_NoPinned_AndDocumentHasNoCurrentRevision_Returns_NotFound()
+    {
+        var (links, revisions, link, _) = Seed();
+        link.RevisionId = null;
+        link.Revision = null;
+        link.Document.CurrentRevisionId = null;
+        link.Document.CurrentRevision = null;
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.NotFound);
+        result.Share.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Resolve_NoPinned_CurrentRevisionNotEagerLoaded_FetchesFromRevisionStore()
+    {
+        // The common path is eager-loaded; this exercises the defensive fallback
+        // where only CurrentRevisionId is set and the resolver must hydrate it.
+        var (links, revisions, link, _) = Seed();
+        link.RevisionId = null;
+        link.Revision = null;
+        var fallback = NewRevision(link.DocumentId, "# Fallback");
+        link.Document.CurrentRevisionId = fallback.Id;
+        link.Document.CurrentRevision = null;
+        revisions.Add(fallback);
+
+        var result = await new ShareLinkResolver(links, revisions).ResolveAsync(ValidToken, Now, default);
+
+        result.State.Should().Be(ShareState.Ok);
+        result.Share!.Revision.Should().BeSameAs(fallback);
+        revisions.LookupCount.Should().Be(1);
+    }
+
+    // --- fixture wiring -----------------------------------------------------
+
+    private static (InMemoryShareLinkStore Links, InMemoryRevisionStore Revisions, ShareLink Link, Revision CurrentRev)
+        Seed()
+    {
+        var repo = new Repository
+        {
+            Id = Guid.NewGuid(),
+            Name = "Notes",
+            Slug = "notes",
+            OwnerId = Guid.NewGuid(),
+            Owner = new User
+            {
+                Id = Guid.NewGuid(),
+                Username = "alice",
+                Email = "alice@example.com",
+            },
+        };
+        var docId = Guid.NewGuid();
+        var currentRev = NewRevision(docId, "# Current");
+        var doc = new Document
+        {
+            Id = docId,
+            RepositoryId = repo.Id,
+            Path = "guide.md",
+            CurrentRevisionId = currentRev.Id,
+            CurrentRevision = currentRev,
+        };
+        var link = new ShareLink
+        {
+            Id = Guid.NewGuid(),
+            RepositoryId = repo.Id,
+            DocumentId = doc.Id,
+            TokenHash = ShareLinkTokenService.HashToken(ValidToken),
+            TokenPrefix = "sl_valid",
+            Repository = repo,
+            Document = doc,
+        };
+
+        var links = new InMemoryShareLinkStore();
+        links.Add(link);
+        return (links, new InMemoryRevisionStore(), link, currentRev);
+    }
+
+    private static Revision NewRevision(Guid documentId, string content) => new()
+    {
+        Id = Guid.NewGuid(),
+        DocumentId = documentId,
+        Content = content,
+        Message = "rev",
+    };
+}
+
+// Only GetByTokenHashAsync is exercised by the resolver; the remaining members
+// throw so an accidental dependency on them surfaces loudly.
+internal sealed class InMemoryShareLinkStore : IShareLinkStore
+{
+    private readonly Dictionary<string, ShareLink> _byHash = [];
+    public int LookupCount { get; private set; }
+
+    public void Add(ShareLink link) => _byHash[link.TokenHash] = link;
+
+    public Task<ShareLink?> GetByTokenHashAsync(string tokenHash, CancellationToken ct = default)
+    {
+        LookupCount++;
+        return Task.FromResult(_byHash.TryGetValue(tokenHash, out var link) ? link : null);
+    }
+
+    public Task<ShareLink?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+    public Task<IReadOnlyList<ShareLink>> ListForDocumentAsync(Guid documentId, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+    public Task<IReadOnlyList<ShareLink>> ListForRepositoryAsync(Guid repositoryId, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+    public Task CreateAsync(ShareLink link, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+    public Task UpdateAsync(ShareLink link, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+    public Task MarkAccessedAsync(Guid id, DateTime when, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}
+
+// Only GetByIdAsync is exercised (the defensive current-revision fallback).
+internal sealed class InMemoryRevisionStore : IRevisionStore
+{
+    private readonly Dictionary<Guid, Revision> _byId = [];
+    public int LookupCount { get; private set; }
+
+    public void Add(Revision revision) => _byId[revision.Id] = revision;
+
+    public Task<Revision?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        LookupCount++;
+        return Task.FromResult(_byId.TryGetValue(id, out var rev) ? rev : null);
+    }
+
+    public Task<IReadOnlyList<Revision>> ListByDocumentAsync(Guid documentId, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+    public Task<Revision> CreateAsync(Revision revision, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/tests/Scribegate.Web.Tests/ShareLinkMediaTests.cs
+++ b/tests/Scribegate.Web.Tests/ShareLinkMediaTests.cs
@@ -60,6 +60,8 @@ public class ShareLinkMediaTests
         resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    // The media path now shares the document path's lifecycle contract: a revoked
+    // token yields 410 Gone (was 404 before the share-link-lifecycle unification).
     [Fact]
     public async Task Revoked_ShareLink_Cannot_Fetch_Media()
     {
@@ -81,7 +83,37 @@ public class ShareLinkMediaTests
         var resp = await anonymous.GetAsync(
             $"/api/v1/shares/{share.Token}/media/by-name/diagram.png");
 
-        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        resp.StatusCode.Should().Be(HttpStatusCode.Gone);
+    }
+
+    // Pins the historical drift closed: GET /shares/{token} and
+    // GET /shares/{token}/media/by-name/{file} must report the SAME lifecycle
+    // status for a revoked link (both 410 Gone), so a public viewer never gets a
+    // helpful "expired/revoked" page whose images 404.
+    [Fact]
+    public async Task Revoked_ShareLink_DocumentAndMedia_ReturnSameStatus()
+    {
+        await using var factory = new ScribegateWebAppFactory();
+        var owner = factory.CreateClient();
+        var (_, ownerToken) = await RegisterAsync(owner, "owner");
+        Authenticate(owner, ownerToken);
+
+        var repo = await CreateRepoAsync(owner, "revoke-parity");
+        await CreateDocumentAsync(owner, repo, "guide.md");
+        await UploadMediaAsync(owner, repo, "diagram.png");
+        var share = await CreateShareAsync(owner, repo, "guide.md");
+
+        var revoke = await owner.DeleteAsync(
+            $"/api/v1/repositories/{repo.Owner}/{repo.Slug}/shares/{share.Id}");
+        revoke.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var anonymous = factory.CreateClient();
+        var docResp = await anonymous.GetAsync($"/api/v1/shares/{share.Token}");
+        var mediaResp = await anonymous.GetAsync(
+            $"/api/v1/shares/{share.Token}/media/by-name/diagram.png");
+
+        docResp.StatusCode.Should().Be(HttpStatusCode.Gone);
+        mediaResp.StatusCode.Should().Be(docResp.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
Implements **#12**. Consolidates share-link *consumption* behind one deep module and fixes the documented 404-vs-410 drift.

## What changed
- **`Scribegate.Core.ShareLinks.ShareLinkResolver`** (read-only, `(IShareLinkStore, IRevisionStore)`) now owns the single sequence: prefix-check → `HashToken` → lookup → revoked → expired → pinned-vs-current revision selection, returning a discriminated **`ShareResolution(ShareState, ResolvedShare?)`**. `now` is a method parameter (no `IClock`/`TimeProvider` — the codebase has none).
- **`ShareResolutionExtensions.ToError()`** (Web) is the *one* lifecycle→HTTP mapping (404 / 410), separate from `PolicyResultExtensions.ToHttp()` because `PolicyResult` only models {200,403,409,422}.
- **`RepoMediaResolver.StreamByNameAsync`** (Web, static) is a single repo-scoped media-by-name seam — sanitize → `FindLatestByFileNameAsync` → `File.Exists` → `Results.File` — reused by **both** the anonymous share path and `MediaEndpoints.DownloadMediaByName`. The duplicated copies are gone.
- Token primitives (`ShareLinkTokenService` / `ShareLinkTokenDefaults`) moved **Web→Core** (git tracked it as a rename).
- **`ShareLinkLifecycle`** single-sources the revoked/expired predicate so the resolver and the owner-facing listing's `IsActive` agree at the exact-equality tick.
- `architecture-friction.md` candidate **#4** flipped to ✅ done.

## ⚠️ Behavior change
`GET /api/v1/shares/{token}/media/by-name/{fileName}` now returns **410** (`REVOKED` / `EXPIRED`) instead of **404** for revoked/expired links, matching `GET /api/v1/shares/{token}`. Media fetches still do **not** bump `AccessCount` or emit `ShareLinkAccessedEvent`.

## Rejected designs (per the RFC)
No `CreateAsync` on the resolver (creation + RBAC stays at the endpoint); no `Func<IResult>` not-found closure (one `ToError()` switch); not a status-quo inline 404→410 patch.

## Tests
- New `ShareLinkResolverTests` (Core, 16): every `ShareState` branch, pinned-vs-current selection + defensive `revisionStore` fallback, expiry boundary pinned (`==now` is **not** expired), prefix short-circuits before any DB hit.
- `ShareLinkMediaTests`: 404→410 alignment + new `Revoked_ShareLink_DocumentAndMedia_ReturnSameStatus` parity test.
- **Core 119/119, Web ShareLink 10/10**, solution build clean (0 warnings).

## Review
Built via the implement → test → review → verify pipeline: **0 blocking / 0 should-fix**, spec conformance **12/12 (conforms)**. The three follow-up nits (docs legend, `ToError` fail-loud `Ok` arm, single-sourced `IsActive` boundary) are applied in this branch.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
