### PR TITLE
fix(deps): bump transitive qs to 6.15.2 (CVE-2026-8723, Dependabot #9)

### DIFF
--- a/src/Scribegate.Web/Client/package-lock.json
+++ b/src/Scribegate.Web/Client/package-lock.json
@@ -5405,9 +5405,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/src/Scribegate.Web/Client/package.json
+++ b/src/Scribegate.Web/Client/package.json
@@ -25,7 +25,8 @@
     "prismjs": "^1.30.0"
   },
   "overrides": {
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "qs": "^6.15.2"
   },
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",


### PR DESCRIPTION
Resolves **Dependabot alert #9** — `qs` / CVE-2026-8723 / GHSA-q8mj-m7cp-5q26.

## Fix
Adds a `package.json` override forcing `qs: ^6.15.2`, lifting the single transitive `qs@6.15.1` to `6.15.2` (the first patched release). The lockfile change is the `qs` entry only.

## Risk context
- **Dev-only, transitive.** `qs` is reachable solely through `@open-wc/testing → @web/test-runner-commands → @web/test-runner-core → co-body` (the SPA component-test toolchain). It is **never** in `dependencies`, **never** bundled into the browser SPA, and **not** in the .NET backend.
- The advisory is a `qs.stringify` DoS that fires only with the non-default combo `arrayFormat: 'comma'` + `encodeValuesOnly: true` on a `null`/`undefined` array element. EPSS 0.04%. No production exposure for Scribegate — this is hygiene to clear the alert.
- `co-body` requires `qs: ^6.5.2`, so `6.15.2` is non-breaking.

## Verification
- `qs` resolves to **6.15.2** (`npm ls qs`), out of the vulnerable range.
- SPA build green; **71/71 vitest tests pass** (the `@open-wc/testing` suite that exercises this dependency).

## Heads-up — separate, out of scope here
Local `npm audit` (real-time against the GitHub Advisory DB) flags two more that GitHub Dependabot hasn't surfaced yet (likely not re-scanned since they were published):
- `esbuild`/`vite` — **high** (GHSA-gv7w-rqvm-qjhr); fix is a **breaking** `vite` 6 → 8 bump. Needs its own evaluation.
- `ws` (via `jsdom`) — **moderate** (GHSA-58qx-3vcg-4xpx); non-breaking (`npm audit fix`).

Both are dev-only as well. Left out of this PR to keep it a clean, single-advisory fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
