### PR TITLE
chore(deps): apply dotnet patch bumps, hold System.CommandLine (split from #28)

### DIFF
--- a/clients/csharp/Scribegate.Client.csproj
+++ b/clients/csharp/Scribegate.Client.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.5" />
-    <PackageReference Include="System.Text.Json" Version="9.0.5" />
+    <PackageReference Include="System.Net.Http.Json" Version="9.0.17" />
+    <PackageReference Include="System.Text.Json" Version="9.0.17" />
   </ItemGroup>
 
 </Project>

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Hold System.CommandLine on the 2.0.0-beta4 API. The 2.0 GA removed the entire fluent builder surface Scribegate.Cli is written against (~167 call sites across 6 CLI files), so bumping it fails the build. Re-enable once the CLI is migrated to the GA API.",
+      "matchPackageNames": ["System.CommandLine"],
+      "enabled": false
+    }
   ]
 }

--- a/src/Scribegate.Analyzers/Scribegate.Analyzers.csproj
+++ b/src/Scribegate.Analyzers/Scribegate.Analyzers.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Scribegate.Data/Scribegate.Data.csproj
+++ b/src/Scribegate.Data/Scribegate.Data.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Scribegate.Web/Scribegate.Web.csproj
+++ b/src/Scribegate.Web/Scribegate.Web.csproj
@@ -10,14 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="DiffPlex" Version="1.9.0" />

--- a/tests/Scribegate.Data.Tests/Scribegate.Data.Tests.csproj
+++ b/tests/Scribegate.Data.Tests/Scribegate.Data.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="xunit.v3" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/tests/Scribegate.Web.Tests/Scribegate.Web.Tests.csproj
+++ b/tests/Scribegate.Web.Tests/Scribegate.Web.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.v3" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Splits Renovate #28 ("update dotnet monorepo"). #28 bundled a breaking `System.CommandLine` GA bump with routine patch bumps, which broke the `.NET Tests` build on both OSes (the CLI no longer compiled, so no tests ran). This PR takes the safe bumps and holds the breaking one.

## Applied (in-range, low risk)

| Package | From → To |
|---|---|
| Microsoft.AspNetCore.Authentication.JwtBearer / OpenIdConnect / OpenApi | 10.0.6 → 10.0.9 |
| Microsoft.EntityFrameworkCore.Design / .Sqlite, Microsoft.Data.Sqlite | 10.0.6 → 10.0.9 |
| Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore | 10.0.6 → 10.0.9 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.6 → 10.0.9 |
| System.Net.Http.Json / System.Text.Json | 9.0.5 → 9.0.17 |
| Microsoft.CodeAnalysis.CSharp | 4.11.0 → 4.14.0 |

`dotnet build -c Release` passes (0 errors).

## Held back: System.CommandLine 2.0.9 (the 2.0 GA)

The GA removed the entire fluent builder surface `Scribegate.Cli` is written against — `SetHandler`, `AddGlobalOption`, `AddValidator`, `Option.IsRequired`, `RootCommand.InvokeAsync`, the `new Argument<T>(name, desc)` ctor, `GetValueForOption/Argument` — ~167 call sites across 6 CLI files (`Program.cs`, `AuthCommands`, `RepoCommands`, `DocCommands`, `ProposalCommands`, `ReviewCommands`). `renovate.json` now pins it via an `enabled: false` packageRule so Renovate stops re-raising the failing bump.

### Follow-up (not in this PR)

Migrate `Scribegate.Cli` to the System.CommandLine 2.0 GA API, then remove the `renovate.json` hold. #28 to be closed in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHAtcKsNHZYk6SWvpmXeAk