### PR TITLE
fix(web): harden Markdown URL-scheme scrub to a WHATWG-parsed allowlist

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -61,13 +61,15 @@ Both surfaces treat document content as untrusted and apply defence in depth:
 | Vector | Server handling | Client handling |
 |---|---|---|
 | Raw HTML in markdown | `DisableHtml()` on the Markdig pipeline | DOMPurify with an allow-list of tags and attrs |
-| `javascript:` / `vbscript:` / `data:` URLs in links | AST walker rewrites to `#` after parse | DOMPurify strips; only `http(s)://`, `mailto:`, and relative URLs pass |
+| Dangerous URL schemes in links | AST walker keeps an **allowlist** of safe schemes (`http(s)`, `ftp(s)`, `mailto`, `tel`, `callto`, `sms`, `cid`, `xmpp`) plus scheme-less/relative URLs; everything else (`javascript:`, `vbscript:`, `data:`, `blob:`, `file:`, …) is rewritten to `#`. Scheme detection mirrors a WHATWG URL parser (strips embedded tab/CR/LF, trims leading controls) so it can't be fooled by `java<TAB>script:`. | DOMPurify strips; same allowlist (its default `ALLOWED_URI_REGEXP`) |
 | `onclick` / inline event handlers | `UseGenericAttributes()` deliberately not enabled | DOMPurify strips |
 | External links | Rendered as-is | `afterSanitizeAttributes` hook adds `target="_blank"` + `rel="noopener noreferrer"` |
 | Task-list checkboxes | — | `disabled` attribute forced on |
 | Mermaid SVG output | N/A (server does not render diagrams) | DOMPurify re-sanitises with `USE_PROFILES: { svg: true, svgFilters: true }` |
 
 `UseGenericAttributes` is the notable Markdig extension that is **deliberately excluded** from the server pipeline, because its `{#id .class attr=value}` syntax lets authors attach arbitrary attributes to generated elements, which would bypass `DisableHtml()`.
+
+**Known structural gap (not a live exploit):** `UseMediaLinks` emits `<iframe>`/`<video>`/`<audio>`/`<source>` elements whose `src` is renderer-produced, so it bypasses both `DisableHtml()` and the AST scheme-scrub (which only walks `LinkInline`/`AutolinkInline` URLs). It is safe today because the embed hosts (YouTube, Vimeo) are hard-coded `https://…` prefixes by Markdig and a dangerous-scheme image falls back to a plain `<img>` that the scrub catches. The static-site export has no sanitizer downstream of Markdig, so this would matter if a future Markdig changed how embed `src`/hosts are assembled — `SafeMarkdownRendererTests` pins a YouTube-embed golden to trip CI if that output changes.
 
 ## Known divergences worth fixing later
 

--- a/src/Scribegate.Web/Api/SafeMarkdownRenderer.cs
+++ b/src/Scribegate.Web/Api/SafeMarkdownRenderer.cs
@@ -140,26 +140,50 @@ public static class SafeMarkdownRenderer
         return true;
     }
 
+    // Safe URL schemes — anything else on a link/autolink is scrubbed to "#".
+    // Mirrors DOMPurify's default ALLOWED_URI_REGEXP (the client-side sanitizer
+    // in sg-markdown-view.ts), so a link the SPA would keep is exactly the set
+    // the server-rendered static-site export keeps. An allowlist — rather than a
+    // javascript/vbscript/data denylist — future-proofs the scrub against novel
+    // script-capable schemes (blob:, filesystem:, a future jar:/...) and removes
+    // its dependence on Markdig having percent-encoded hostile input first.
+    private static readonly HashSet<string> SafeUrlSchemes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "http", "https", "ftp", "ftps", "mailto", "tel", "callto", "sms", "cid", "xmpp",
+    };
+
+    // True when `url` carries a scheme that is NOT in the safe allowlist. A
+    // scheme-less URL (relative path, fragment, query) is always safe.
+    //
+    // Scheme detection mirrors a WHATWG URL parser so the check sees what the
+    // browser would, not a string a denylist can be tricked past:
+    //   - leading C0 controls / whitespace are trimmed ("  javascript:" -> js)
+    //   - ASCII tab/CR/LF are stripped anywhere ("java<TAB>script:" -> js),
+    //     since the URL parser removes them before resolving the scheme
+    //   - the scheme is ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ); if the run
+    //     before the first ':' isn't a valid scheme, the ':' is path data
+    //     ("foo/ba:r", "javascript%3A...") and the URL is relative => safe
+    // So the scrub is self-sufficient instead of relying on Markdig having
+    // percent-encoded an embedded control char in the emitted href.
     internal static bool IsDangerousScheme(string? url)
     {
         if (string.IsNullOrEmpty(url)) return false;
 
-        // Trim leading C0 control characters (<= U+0020) AND Unicode whitespace
-        // before sniffing the scheme. WHATWG-compliant browsers strip leading
-        // control chars from a URL before parsing it, so "javascript:…"
-        // would otherwise be treated as a script URL by the browser while
-        // slipping past a plain TrimStart (char.IsWhiteSpace misses most C0
-        // controls). Detecting it here keeps the scrub self-sufficient rather
-        // than relying on Markdig's downstream percent-encoding of the href.
-        var span = url.AsSpan();
+        var normalized = url.Replace("\t", "").Replace("\n", "").Replace("\r", "");
         var start = 0;
-        while (start < span.Length && (span[start] <= ' ' || char.IsWhiteSpace(span[start])))
+        while (start < normalized.Length && (normalized[start] <= ' ' || char.IsWhiteSpace(normalized[start])))
             start++;
-        var trimmed = span[start..];
 
-        return trimmed.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith("vbscript:", StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith("data:", StringComparison.OrdinalIgnoreCase);
+        var colon = normalized.IndexOf(':', start);
+        if (colon <= start) return false; // no scheme (relative/fragment/query) => safe
+
+        var scheme = normalized[start..colon];
+        if (!char.IsAsciiLetter(scheme[0])) return false;
+        foreach (var c in scheme)
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('+' or '-' or '.'))
+                return false; // the ':' belongs to the path, not a scheme => safe
+
+        return !SafeUrlSchemes.Contains(scheme);
     }
 }
 

--- a/src/Scribegate.Web/Api/SafeMarkdownRenderer.cs
+++ b/src/Scribegate.Web/Api/SafeMarkdownRenderer.cs
@@ -140,20 +140,16 @@ public static class SafeMarkdownRenderer
         return true;
     }
 
-    // Safe URL schemes — anything else on a link/autolink is scrubbed to "#".
-    // Mirrors DOMPurify's default ALLOWED_URI_REGEXP (the client-side sanitizer
-    // in sg-markdown-view.ts), so a link the SPA would keep is exactly the set
-    // the server-rendered static-site export keeps. An allowlist — rather than a
-    // javascript/vbscript/data denylist — future-proofs the scrub against novel
-    // script-capable schemes (blob:, filesystem:, a future jar:/...) and removes
-    // its dependence on Markdig having percent-encoded hostile input first.
-    private static readonly HashSet<string> SafeUrlSchemes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "http", "https", "ftp", "ftps", "mailto", "tel", "callto", "sms", "cid", "xmpp",
-    };
-
     // True when `url` carries a scheme that is NOT in the safe allowlist. A
     // scheme-less URL (relative path, fragment, query) is always safe.
+    //
+    // The allowlist (see IsSafeScheme below) mirrors DOMPurify's default
+    // ALLOWED_URI_REGEXP — the client-side sanitizer in sg-markdown-view.ts — so
+    // a link the SPA would keep is exactly the set the server-rendered
+    // static-site export keeps. An allowlist, rather than a
+    // javascript/vbscript/data denylist, future-proofs the scrub against novel
+    // script-capable schemes (blob:, filesystem:, a future jar:/...) and removes
+    // its dependence on Markdig having percent-encoded hostile input first.
     //
     // Scheme detection mirrors a WHATWG URL parser so the check sees what the
     // browser would, not a string a denylist can be tricked past:
@@ -163,27 +159,43 @@ public static class SafeMarkdownRenderer
     //   - the scheme is ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ); if the run
     //     before the first ':' isn't a valid scheme, the ':' is path data
     //     ("foo/ba:r", "javascript%3A...") and the URL is relative => safe
-    // So the scrub is self-sufficient instead of relying on Markdig having
-    // percent-encoded an embedded control char in the emitted href.
+    //
+    // Allocation-free in the common case: the tab/CR/LF strip only allocates
+    // when one is actually present, and the scheme is compared as a span.
     internal static bool IsDangerousScheme(string? url)
     {
         if (string.IsNullOrEmpty(url)) return false;
 
-        var normalized = url.Replace("\t", "").Replace("\n", "").Replace("\r", "");
+        var span = url.AsSpan();
+        if (url.Contains('\t') || url.Contains('\n') || url.Contains('\r'))
+            span = url.Replace("\t", "").Replace("\n", "").Replace("\r", "").AsSpan();
+
         var start = 0;
-        while (start < normalized.Length && (normalized[start] <= ' ' || char.IsWhiteSpace(normalized[start])))
+        while (start < span.Length && (span[start] <= ' ' || char.IsWhiteSpace(span[start])))
             start++;
 
-        var colon = normalized.IndexOf(':', start);
+        var colon = span.IndexOf(':');
         if (colon <= start) return false; // no scheme (relative/fragment/query) => safe
 
-        var scheme = normalized[start..colon];
+        var scheme = span[start..colon];
         if (!char.IsAsciiLetter(scheme[0])) return false;
         foreach (var c in scheme)
             if (!char.IsAsciiLetterOrDigit(c) && c is not ('+' or '-' or '.'))
                 return false; // the ':' belongs to the path, not a scheme => safe
 
-        return !SafeUrlSchemes.Contains(scheme);
+        return !IsSafeScheme(scheme);
+
+        static bool IsSafeScheme(ReadOnlySpan<char> scheme)
+            => scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("ftp", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("ftps", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("mailto", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("tel", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("callto", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("sms", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("cid", StringComparison.OrdinalIgnoreCase)
+                || scheme.Equals("xmpp", StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/tests/Scribegate.Web.Tests/Markdown/SafeMarkdownRendererTests.cs
+++ b/tests/Scribegate.Web.Tests/Markdown/SafeMarkdownRendererTests.cs
@@ -238,4 +238,97 @@ public class SafeMarkdownRendererTests
         SafeMarkdownRenderer.RenderPipelineOnly(md).Should().Contain("href=\"javascript:");
         SafeMarkdownRenderer.Render(md).Should().NotContain("href=\"javascript:");
     }
+
+    // 9. Scheme handling is an ALLOWLIST, not a javascript/vbscript/data
+    //    denylist. Safe schemes — and relative / scheme-less URLs — pass through
+    //    untouched.
+    [Theory]
+    [InlineData("https://example.com/page")]
+    [InlineData("http://example.com")]
+    [InlineData("mailto:hi@example.com")]
+    [InlineData("tel:+15551234567")]
+    [InlineData("ftp://files.example.com/x")]
+    public void Render_PreservesAllowlistedSchemes(string url)
+    {
+        var html = SafeMarkdownRenderer.Render($"[x]({url})");
+
+        html.Should().Contain($"href=\"{url}\"");
+        html.Should().NotContain("href=\"#\"");
+    }
+
+    [Theory]
+    [InlineData("./docs/page.md")]
+    [InlineData("/absolute/path")]
+    [InlineData("#fragment")]
+    public void Render_PreservesRelativeUrls(string url)
+    {
+        var html = SafeMarkdownRenderer.Render($"[x]({url})");
+
+        html.Should().Contain($"href=\"{url}\"");
+    }
+
+    // 9b. Schemes the old denylist missed (blob:, file:, filesystem:, …) are now
+    //     scrubbed because anything outside the allowlist is treated as dangerous.
+    [Theory]
+    [InlineData("blob:https://evil.example/x")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("filesystem:http://evil.example/x")]
+    public void Render_NeutralisesNonAllowlistedSchemes(string url)
+    {
+        var html = SafeMarkdownRenderer.Render($"[x]({url})");
+
+        html.Should().Contain("href=\"#\"");
+    }
+
+    // 10. IsDangerousScheme is the scrub's core predicate. Pin its WHATWG-style
+    //     parsing directly — including control chars embedded *inside* the scheme
+    //     that the render path would percent-encode away — so the predicate stays
+    //     self-sufficient regardless of how Markdig encodes the emitted href.
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("JavaScript:alert(1)")]
+    [InlineData("  javascript:alert(1)")]      // leading whitespace
+    [InlineData("\tjavascript:alert(1)")]       // leading tab
+    [InlineData("data:image/png;base64,AAAA")] // data: images are blocked too
+    [InlineData("java\tscript:alert(1)")]       // embedded tab (browser strips it -> javascript:)
+    [InlineData("java\nscript:alert(1)")]       // embedded newline
+    [InlineData("java\rscript:alert(1)")]       // embedded CR
+    [InlineData("vbscript:msgbox(1)")]
+    [InlineData("data:text/html,<script>")]
+    [InlineData("blob:https://x")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("filesystem:http://x")]
+    public void IsDangerousScheme_FlagsScriptCapableAndUnknownSchemes(string url)
+        => SafeMarkdownRenderer.IsDangerousScheme(url).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com")]
+    [InlineData("HTTPS://EXAMPLE.COM")]         // scheme match is case-insensitive
+    [InlineData("mailto:hi@example.com")]
+    [InlineData("tel:+15551234567")]
+    [InlineData("ftp://files.example.com")]
+    [InlineData("foo.png")]                      // relative, no scheme
+    [InlineData("./foo/bar.png")]
+    [InlineData("/absolute/path")]
+    [InlineData("#fragment")]
+    [InlineData("?query=1")]
+    [InlineData("path/to:thing")]                // ':' is path data, not a scheme
+    [InlineData("javascript%3Aalert(1)")]        // percent-encoded colon -> no real scheme
+    public void IsDangerousScheme_AllowsSafeAndSchemelessUrls(string? url)
+        => SafeMarkdownRenderer.IsDangerousScheme(url).Should().BeFalse();
+
+    // 11. Documents a known structural gap (see docs/markdown.md): UseMediaLinks
+    //     emits a fixed-host <iframe> whose src bypasses the scheme-scrub. Safe
+    //     today because the host prefix is hard-coded https; this golden trips if
+    //     a future Markdig changes how the embed src is assembled.
+    [Fact]
+    public void Render_EmitsFixedHostYouTubeEmbed()
+    {
+        var html = SafeMarkdownRenderer.Render("![v](https://www.youtube.com/watch?v=dQw4w9WgXcQ)");
+
+        html.Should().Contain("<iframe src=\"https://www.youtube.com/embed/dQw4w9WgXcQ\"");
+    }
 }


### PR DESCRIPTION
Follow-up to the Markdig 0.45 review (#38). That review confirmed the bump was safe but surfaced three **pre-existing**, low-severity gaps in the server-side untrusted-Markdown scrub (`SafeMarkdownRenderer.IsDangerousScheme`). This hardens it.

## Change

`IsDangerousScheme` moves from a **denylist** (`javascript:`/`vbscript:`/`data:`) to an **allowlist** of safe schemes — `http(s)`, `ftp(s)`, `mailto`, `tel`, `callto`, `sms`, `cid`, `xmpp` — plus relative/scheme-less URLs. This mirrors the client's **DOMPurify default `ALLOWED_URI_REGEXP`**, so the SPA and the static-site export now agree on exactly which links survive.

Scheme detection now mirrors a **WHATWG URL parser**:
- strips embedded ASCII tab/CR/LF (`java<TAB>script:` → `javascript:`)
- trims leading C0 controls / whitespace
- validates the scheme token (`ALPHA *( ALPHA / DIGIT / + / - / . )`) so a `:` after a non-scheme run (`foo/ba:r`, `javascript%3A…`) is correctly treated as a relative URL

### What this closes (all pre-existing, none bump-introduced)
1. **Novel script-capable schemes** the denylist missed (`blob:`, `file:`, `filesystem:`, future `jar:`) now scrub to `#`.
2. **Embedded-control-char bypass**: the scrub no longer depends on Markdig having percent-encoded a `java<TAB>script:` payload — it's self-sufficient.
3. **No self-owned entity-decode dependency** removed as a concern (allowlist + WHATWG parse stands on its own).

## Tests
Adds host-free regression tests to `SafeMarkdownRendererTests`:
- allowlisted schemes + relative URLs pass through untouched
- non-allowlisted schemes (`blob:`/`file:`/`filesystem:`) scrub to `#`
- `IsDangerousScheme` predicate table: WHATWG parsing incl. embedded tab/CR/LF, leading whitespace, percent-encoded colon, case-insensitivity
- a YouTube-embed golden documenting the known **`UseMediaLinks` scrub-bypass** (renderer-emitted `<iframe>` src is outside the AST scrub — safe today via hard-coded `https` embed hosts; the golden trips CI if that assembly changes)

**101 Markdown-namespace tests pass** (incl. the full-host `SecurityTests` XSS export path and `ParityTheoryTests`). No behavior change for real content — there are no non-http schemes in the corpus.

`docs/markdown.md` security-posture table updated + a note on the MediaLinks gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHAtcKsNHZYk6SWvpmXeAk