### PR TITLE
test: migrate FluentAssertions 7 → AwesomeAssertions 9 (avoid v8 commercial license)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
       "description": "Hold System.CommandLine on the 2.0.0-beta4 API. The 2.0 GA removed the entire fluent builder surface Scribegate.Cli is written against (~167 call sites across 6 CLI files), so bumping it fails the build. Re-enable once the CLI is migrated to the GA API.",
       "matchPackageNames": ["System.CommandLine"],
       "enabled": false
+    },
+    {
+      "description": "Migrated off FluentAssertions to AwesomeAssertions (the free Apache-2.0 fork) because FluentAssertions v8+ is commercially licensed (Xceed) and Scribegate runs a commercial managed tier. Guard against any accidental reintroduction of FluentAssertions pulling in the commercial line.",
+      "matchPackageNames": ["FluentAssertions"],
+      "allowedVersions": "<8"
     }
   ]
 }

--- a/tests/Scribegate.Core.Tests/Authorization/CommentPolicyTests.cs
+++ b/tests/Scribegate.Core.Tests/Authorization/CommentPolicyTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Authorization;
 using Scribegate.Core.Entities;
 using Xunit;

--- a/tests/Scribegate.Core.Tests/Authorization/ProposalPolicyTests.cs
+++ b/tests/Scribegate.Core.Tests/Authorization/ProposalPolicyTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Authorization;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;

--- a/tests/Scribegate.Core.Tests/Authorization/ShareLinkPolicyTests.cs
+++ b/tests/Scribegate.Core.Tests/Authorization/ShareLinkPolicyTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Authorization;
 using Scribegate.Core.Entities;
 using Xunit;

--- a/tests/Scribegate.Core.Tests/DocumentCommandServiceTests.cs
+++ b/tests/Scribegate.Core.Tests/DocumentCommandServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Services;
 using Xunit;

--- a/tests/Scribegate.Core.Tests/EntityInvariantsTests.cs
+++ b/tests/Scribegate.Core.Tests/EntityInvariantsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;
 using Xunit;

--- a/tests/Scribegate.Core.Tests/MediaCommandServiceTests.cs
+++ b/tests/Scribegate.Core.Tests/MediaCommandServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Services;
 using Xunit;

--- a/tests/Scribegate.Core.Tests/MembershipCommandServiceTests.cs
+++ b/tests/Scribegate.Core.Tests/MembershipCommandServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;
 using Scribegate.Core.Services;

--- a/tests/Scribegate.Core.Tests/ProposalApprovalServiceTests.cs
+++ b/tests/Scribegate.Core.Tests/ProposalApprovalServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;
 using Scribegate.Core.Events;

--- a/tests/Scribegate.Core.Tests/ProposalCommandServiceTests.cs
+++ b/tests/Scribegate.Core.Tests/ProposalCommandServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Authorization;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;

--- a/tests/Scribegate.Core.Tests/Scribegate.Core.Tests.csproj
+++ b/tests/Scribegate.Core.Tests/Scribegate.Core.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.v3" Version="2.0.3" />
-    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>

--- a/tests/Scribegate.Core.Tests/ShareLinkResolverTests.cs
+++ b/tests/Scribegate.Core.Tests/ShareLinkResolverTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.ShareLinks;
 using Scribegate.Core.Stores;

--- a/tests/Scribegate.Data.Tests/AuditRetentionTests.cs
+++ b/tests/Scribegate.Data.Tests/AuditRetentionTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Stores;
 using Scribegate.Data.Stores;

--- a/tests/Scribegate.Data.Tests/BeginTransactionPairingTests.cs
+++ b/tests/Scribegate.Data.Tests/BeginTransactionPairingTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Data.Tests;

--- a/tests/Scribegate.Data.Tests/DomainEventInterceptorTests.cs
+++ b/tests/Scribegate.Data.Tests/DomainEventInterceptorTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Events;

--- a/tests/Scribegate.Data.Tests/FullTextSearchTests.cs
+++ b/tests/Scribegate.Data.Tests/FullTextSearchTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;

--- a/tests/Scribegate.Data.Tests/ProposalStalenessTests.cs
+++ b/tests/Scribegate.Data.Tests/ProposalStalenessTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;
 using Scribegate.Data.Stores;

--- a/tests/Scribegate.Data.Tests/QuotaTests.cs
+++ b/tests/Scribegate.Data.Tests/QuotaTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;
 using Scribegate.Data.Stores;

--- a/tests/Scribegate.Data.Tests/RevisionTests.cs
+++ b/tests/Scribegate.Data.Tests/RevisionTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;
 using Scribegate.Data.Stores;

--- a/tests/Scribegate.Data.Tests/Scribegate.Data.Tests.csproj
+++ b/tests/Scribegate.Data.Tests/Scribegate.Data.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="xunit.v3" Version="2.0.3" />
-    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 

--- a/tests/Scribegate.Data.Tests/SoftArchiveTests.cs
+++ b/tests/Scribegate.Data.Tests/SoftArchiveTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Scribegate.Core.Entities;
 using Scribegate.Core.Enums;

--- a/tests/Scribegate.Web.Tests/AuthRegistrationTests.cs
+++ b/tests/Scribegate.Web.Tests/AuthRegistrationTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/CommentThreadTests.cs
+++ b/tests/Scribegate.Web.Tests/CommentThreadTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/DomainEventBusTests.cs
+++ b/tests/Scribegate.Web.Tests/DomainEventBusTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Scribegate.Core.Events;

--- a/tests/Scribegate.Web.Tests/EmailQueueTests.cs
+++ b/tests/Scribegate.Web.Tests/EmailQueueTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Scribegate.Web.Services;
 using Xunit;

--- a/tests/Scribegate.Web.Tests/ExportSiteEndpointsTests.cs
+++ b/tests/Scribegate.Web.Tests/ExportSiteEndpointsTests.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/GitCloneTests.cs
+++ b/tests/Scribegate.Web.Tests/GitCloneTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/HealthTests.cs
+++ b/tests/Scribegate.Web.Tests/HealthTests.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/Markdown/ParityTheoryTests.cs
+++ b/tests/Scribegate.Web.Tests/Markdown/ParityTheoryTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Web.Api;
 using Xunit;
 

--- a/tests/Scribegate.Web.Tests/Markdown/SafeMarkdownRendererTests.cs
+++ b/tests/Scribegate.Web.Tests/Markdown/SafeMarkdownRendererTests.cs
@@ -1,5 +1,5 @@
 using System.Text.RegularExpressions;
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Web.Api;
 using Xunit;
 

--- a/tests/Scribegate.Web.Tests/Markdown/SecurityTests.cs
+++ b/tests/Scribegate.Web.Tests/Markdown/SecurityTests.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests.Markdown;

--- a/tests/Scribegate.Web.Tests/MediaRbacTests.cs
+++ b/tests/Scribegate.Web.Tests/MediaRbacTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/NotificationPreferencesTests.cs
+++ b/tests/Scribegate.Web.Tests/NotificationPreferencesTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/OidcEndToEndTests.cs
+++ b/tests/Scribegate.Web.Tests/OidcEndToEndTests.cs
@@ -3,7 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Hosting;

--- a/tests/Scribegate.Web.Tests/OidcSecurityTests.cs
+++ b/tests/Scribegate.Web.Tests/OidcSecurityTests.cs
@@ -1,5 +1,5 @@
 using System.Security.Claims;
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Web.Api;
 using Xunit;
 

--- a/tests/Scribegate.Web.Tests/OwnerSlugRoutingTests.cs
+++ b/tests/Scribegate.Web.Tests/OwnerSlugRoutingTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/ProposalFlowTests.cs
+++ b/tests/Scribegate.Web.Tests/ProposalFlowTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/RateLimitTests.cs
+++ b/tests/Scribegate.Web.Tests/RateLimitTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/RbacContractTests.cs
+++ b/tests/Scribegate.Web.Tests/RbacContractTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/Scribegate.Web.Tests.csproj
+++ b/tests/Scribegate.Web.Tests/Scribegate.Web.Tests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.v3" Version="2.0.3" />
-    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>

--- a/tests/Scribegate.Web.Tests/SearchEndToEndTests.cs
+++ b/tests/Scribegate.Web.Tests/SearchEndToEndTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/SecurityRegressionTests.cs
+++ b/tests/Scribegate.Web.Tests/SecurityRegressionTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/ShareLinkEndpointsTests.cs
+++ b/tests/Scribegate.Web.Tests/ShareLinkEndpointsTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/ShareLinkMediaTests.cs
+++ b/tests/Scribegate.Web.Tests/ShareLinkMediaTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/TemplateEndpointsTests.cs
+++ b/tests/Scribegate.Web.Tests/TemplateEndpointsTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Scribegate.Web.Tests;

--- a/tests/Scribegate.Web.Tests/WebhookSigningTests.cs
+++ b/tests/Scribegate.Web.Tests/WebhookSigningTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Scribegate.Web.Services;
 using Xunit;
 


### PR DESCRIPTION
## Why

FluentAssertions **v8+** dropped Apache-2.0 for a **paid Xceed commercial license**. That license applies to test/CI use, not just shipped code — and Scribegate runs a commercial managed tier (Hansen Consultancy CommV). Renovate #55 proposed bumping `FluentAssertions` 7.2.2 → 8.10.0, which would adopt the commercial license. This migrates off it instead.

## What

- All three test projects: `FluentAssertions` 7.2.2 → **`AwesomeAssertions` 9.4.0** (the free Apache-2.0 community fork of FA).
- Renamed `using FluentAssertions;` → `using AwesomeAssertions;` across 42 test files. The `.Should()` assertion API is identical — only the root namespace changed (AwesomeAssertions 9.x uses the `AwesomeAssertions` namespace, not a drop-in `FluentAssertions` one).
- `renovate.json` now pins `FluentAssertions` to `<8` as a guard against accidental reintroduction of the commercial line.

## Verification

Full suite green locally: **357 tests pass** (Core 119, Data 30, Web 208), 0 failed.

Supersedes #55 (which I'll close once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01AHAtcKsNHZYk6SWvpmXeAk